### PR TITLE
Update README. Add docs for Rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Fork and Release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trashed (3.2.6)
+    barnes (0.0.1)
       statsd-ruby (~> 1.1)
 
 GEM
@@ -15,9 +15,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  barnes!
   minitest (~> 5.3)
   rake (~> 10)
-  trashed!
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -1,157 +1,47 @@
-## Trashed
-# Keep an eye on resource usage.
+## Barnes - GC Statsd Reporter
 
-
- - Sends per-request object counts, heap growth, GC time, and more to StatsD.
- - Sends snapshots of resource usage, e.g. live String objects, to StatsD.
- - Supports new stuff: Rails 5.1 and latest Ruby 2.x features.
- - Supports old stuff: Rails 2/3/4, Ruby 1.9+, REE, Ruby 1.8 with RubyBench patches.
+A fork of [trashed](https://github.com/basecamp/trashed) focused on Ruby metrics for Heroku.
 
 ## Setup
 
 ### Rails 5
 
-On Rails 5 (and Rails 3 and 4), add this to the top of `config/application.rb`:
+On Rails 5 (and Rails 3 and 4), add this to your Gemfile:
 
-    require 'trashed/railtie'
-
-And in the body of your app config:
-
-    module YourApp
-      class Application < Rails::Application
-        config.trashed.statsd = YourApp.statsd
-
-
-### Rails 2
-
-On Rails 2, add the middleware to `config/environment.rb`:
-
-    Rails::Initializer.run do |config|
-      reporter = Trashed::Reporter.new
-      reporter.logger = Rails.logger
-      reporter.statsd = YourApp.statsd
-
-      config.middleware.use Trashed::Rack, reporter
-    end
-
-
-### Custom dimensions
-
-You probably want stats per controller, action, right?
-
-Set a `#timing_dimensions` lambda to return a list of dimensions to
-qualify per-request measurements like time elapsed, GC time, objects
-allocated, etc.
-
-For example:
-```ruby
-config.trashed.timing_dimensions = ->(env) do
-  # Rails 3, 4, and 5, set this. Other Rack endpoints won't have it.
-  if controller = env['action_controller.instance']
-    name    = controller.controller_name
-    action  = controller.action_name
-    format  = controller.rendered_format || :none
-    variant = controller.request.variant || :none  # Rails 4.1+ only!
-
-    [ :All,
-      :"Controllers.#{name}",
-      :"Actions.#{name}.#{action}.#{format}+#{variant}" ]
-  end
-end
+```
+gem "barnes"
 ```
 
-Results in metrics like:
+Then run:
+
 ```
-YourNamespace.All.Time.wall
-YourNamespace.Controllers.SessionsController.Time.wall
-YourNamespace.Actions.SessionsController.index.json+phone.Time.wall
+$ bundle install
 ```
 
+### Non-Rails
 
-Similarly, set a `#gauge_dimensions` lambda to return a list of dimensions to
-qualify measurements which gauge current state, like heap slots used or total
-number of live String objects.
+Add the gem to the Gemfile
 
-For example:
+```
+gem "barnes"
+```
+
+Then run:
+
+```
+$ bundle install
+```
+
+In your application:
+
 
 ```ruby
-config.trashed.gauge_dimensions = ->(env) {
-  [ :All,
-    :"Stage.#{Rails.env}",
-    :"Hosts.#{`hostname -s`.chomp}" ]
-}
+require 'barnes'
 ```
 
-Results in metrics like:
+Then you'll need to start the client with default values:
+
+```ruby
+Barnes.start
 ```
-YourNamespace.All.Objects.T_STRING
-YourNamespace.Stage.production.Objects.T_STRING
-YourNamespace.Hosts.host-001.Objects.T_STRING
-```
 
-
-### Version history
-
-*3.2.6* (June 21, 2017)
-
-* Mention Rails 5 support
-
-*3.2.5* (Feb 26, 2015)
-
-* Support Ruby 2.2 GC.stat naming, avoiding 2.1 warnings
-
-*3.2.4* (July 25, 2014)
-
-* Fix compatibility with Rails 3.x tagged logging - @calavera
-
-*3.2.3* (June 23, 2014)
-
-* Report CPU/Idle time in tenths of a percent
-
-*3.2.2* (March 31, 2014)
-
-* Reduce default sampling rates.
-* Stop gauging all GC::Profiler data. Too noisy.
-* Report gauge readings as StatsD timings.
-* Support providing a Statsd::Batch since using Statsd#batch
-  results in underfilled packets at low sample rates.
-* Fix bug with sending arrays of timings to StatsD.
-* Record GC timings in milliseconds.
-
-*3.1.0* (March 30, 2014)
-
-* Report percent CPU/idle time: Time.pct.cpu and Time.pct.idle.
-* Measure out-of-band GC count, time, and stats. Only meaningful for
-  single-threaded servers like Unicorn. But then again so is per-request
-  GC monitoring.
-* Support @tmm1's GC::OOB (https://github.com/tmm1/gctools).
-* Measure time between GCs.
-* Spiff up logger reports with more timings.
-* Support Rails log tags on logged reports.
-* Allow instruments' #start to set timings/gauges.
-
-*3.0.1* (March 30, 2014)
-
-* Sample requests to instrument based on StatsD sample rate.
-
-*3.0.0* (March 29, 2014)
-
-* Support new Ruby 2.0 and 2.1 GC stats.
-* Gauge GC details with GC::Profiler.
-* Performance rework. Faster, fewer allocations.
-* Rework counters and gauges as instruments.
-* Batch StatsD messages to decrease overhead on the server.
-* Drop NewRelic samplers.
-
-*2.0.5* (December 15, 2012)
-
-* Relax outdated statsd-ruby dependency.
-
-*2.0.0* (December 1, 2011)
-
-* Rails 3 support.
-* NewRelic samplers.
-
-*1.0.0* (August 24, 2009)
-
-* Initial release.

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name      = 'barnes'
-  s.version   = '3.2.6'
+  s.version   = '0.0.1'
   s.license   = 'MIT'
   s.summary   = 'Ruby GC stats => StatsD'
   s.description = 'Report GC usage data to StatsD.'
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email     = 'agwozdziewycz@salesforce.com'
 
   s.add_runtime_dependency 'statsd-ruby', '~> 1.1'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'minitest', '~> 5.3'

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -1,2 +1,40 @@
+module Barnes
+  DEFAULT_INTERVAL           = 10
+  DEFAULT_AGGREGATION_PERIOD = 60
+  DEFAULT_STATSD             = :default
+  DEFAULT_PANELS             = []
+
+
+  # Starts the reporting client
+  #
+  # Arguments:
+  #
+  #   - interval: How often, in seconds, to instrument and report
+  #   - aggregation_period: The minimal aggregation period in use, in seconds.
+  #   - statsd: The statsd reporter. This should be an instance of statsd-ruby
+  #   - panels: The instrumentation "panels" in use. See `resource_usage.rb` for
+  #     an example panel, which is the default if none are provided.
+  def self.start(interval: DEFAULT_INTERVAL, aggregation_period: DEFAULT_AGGREGATION_PERIOD, statsd: DEFAULT_STATSD, panels: DEFAULT_PANELS)
+    require 'statsd'
+    statsd_client = statsd
+    panels        = panels
+    sample_rate   = interval.to_f / aggregation_period.to_f
+
+    if statsd_client == :default
+      statsd_client = Statsd.new('127.0.0.1', ENV["PORT"]) if ENV["PORT"]
+    end
+
+    if statsd_client
+      reporter = Barnes::Reporter.new(statsd: statsd_client, sample_rate: sample_rate)
+
+      unless panels.length > 0
+        panels << Barnes::ResourceUsage.new(sample_rate)
+      end
+
+      Periodic.new reporter: reporter, sample_rate: sample_rate, panels: panels
+    end
+  end
+end
+
 require 'barnes/periodic'
 require 'barnes/railtie' if defined? ::Rails::Railtie

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -20,11 +20,11 @@ module Barnes
     panels        = panels
     sample_rate   = interval.to_f / aggregation_period.to_f
 
-    if statsd_client == :default
-      statsd_client = Statsd.new('127.0.0.1', ENV["PORT"]) if ENV["PORT"]
+    if statsd_client == :default && ENV["PORT"]
+      statsd_client = Statsd.new('127.0.0.1', ENV["PORT"])
     end
 
-    if statsd_client
+    if statsd_client && statsd_client != :default
       reporter = Barnes::Reporter.new(statsd: statsd_client, sample_rate: sample_rate)
 
       unless panels.length > 0

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -1,8 +1,11 @@
 require 'barnes/consts'
 
 module Barnes
+  # The periodic class is used to send occasional metrics
+  # to a reporting instance of `Barnes::Reporter` at a semi-regular
+  # rate.
   class Periodic
-    def initialize(reporter, sample_rate = 1, panels = [])
+    def initialize(reporter:, sample_rate: 1, panels: [])
       @reporter = reporter
       @reporter.sample_rate = sample_rate
 
@@ -23,21 +26,19 @@ module Barnes
 
             # read the current values
             env = {
-              STATE => Thread.current[:barnes_state],
+              STATE    => Thread.current[:barnes_state],
               COUNTERS => {},
-              GAUGES => {}
+              GAUGES   => {}
             }
 
             @panels.each do |panel|
               panel.instrument! env[STATE], env[COUNTERS], env[GAUGES]
             end
             @reporter.report env
-          rescue => e
-            # TODO: do something better here...
-            puts e.backtrace.join "\n"
           end
         end
       }
+      @thread.abort_on_exception = true
     end
 
     def stop

--- a/lib/barnes/railtie.rb
+++ b/lib/barnes/railtie.rb
@@ -3,38 +3,24 @@ require 'barnes/reporter'
 require 'barnes/resource_usage'
 
 module Barnes
+  # Automatically configures barnes to run with
+  # rails 3, 4, and 5. Configuration can be changed
+  # in the application.rb. For example
+  #
+  #   module YourApp
+  #     class Application < Rails::Application
+  #     config.barnes[:interval] = 20
+  #
   class Railtie < ::Rails::Railtie
     config.barnes = {
-      # How often, in seconds, to instrument and report
-      :interval => 10,
-
-      # The minimal aggregation period in use, in seconds.
-      :aggregation_period => 60,
-
-      # The statsd reporter. This should be an instance of statsd-ruby
-      :statsd => nil,
-
-      # The instrumentation "panels" in use. See `resource_usage.rb` for
-      # an example panel, which is the default if none are provided.
-      :panels => [],
+      interval:           DEFAULT_INTERVAL,
+      aggregation_period: DEFAULT_AGGREGATION_PERIOD,
+      statsd:             DEFAULT_STATSD,
+      panels:             DEFAULT_PANELS,
     }
 
     initializer 'barnes' do |app|
-      require 'statsd'
-
-      sample_rate = config.barnes[:interval].to_f / config.barnes[:aggregation_period].to_f
-
-      panels = config.barnes[:panels]
-
-      if config.barnes[:statsd]
-        reporter = Barnes::Reporter.new(config.barnes[:statsd], sample_rate)
-
-        unless config.barnes[:panels].length > 0
-          panels << Barnes::ResourceUsage.new(sample_rate)
-        end
-
-        Periodic.new reporter, sample_rate, panels
-      end
+      Barnes.start(config.barnes)
     end
   end
 end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -21,7 +21,7 @@ class ReporterTest < Minitest::Test
 
     statsd = Statsd.new batch
 
-    reporter = Barnes::Reporter.new(statsd, 1)
+    reporter = Barnes::Reporter.new(statsd: statsd, sample_rate: 1)
     reporter.report_statsd \
                 Barnes::COUNTERS => { :'GC.allocated_objects' => 10 }, \
                 Barnes::GAUGES => { :'Time.pct.cpu' => 9.1 }


### PR DESCRIPTION
- prefer named args
- don't use `send` when possible to avoid
- Barnes.start now can be called by Rack for easy starting
- Railties uses Barnes.start
- Prefer aborting when there's an exception in the background thread