### PR TITLE
Add support for Puma Max threads and Spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.6
+
+- Support Puma max threads, support Puma spawned threads
+- Drop Puma backlog metric
+
 ## 0.0.5
 
 - Support Puma pool capacity value #15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    barnes (0.0.5)
+    barnes (0.0.6)
       multi_json (~> 1)
       statsd-ruby (~> 1.1)
 
@@ -12,6 +12,7 @@ GEM
     json (2.1.0)
     minitest (5.10.3)
     multi_json (1.13.1)
+    puma (3.11.4)
     rake (10.5.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -19,6 +20,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     statsd-ruby (1.4.0)
+    wait_for_it (0.1.2)
 
 PLATFORMS
   ruby
@@ -27,8 +29,10 @@ DEPENDENCIES
   barnes!
   bundler (~> 1.15)
   minitest (~> 5.3)
+  puma (~> 3.11)
   rake (~> 10)
   simplecov
+  wait_for_it (~> 0.1)
 
 BUNDLED WITH
    1.16.2

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'multi_json', '~> 1'
 
-  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'rake',     '~> 10'
   spec.add_development_dependency 'minitest', '~> 5.3'
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler",  '~> 1.15'
+  spec.add_development_dependency "puma",     '~> 3.11'
+  spec.add_development_dependency "wait_for_it",     '~> 0.1'
 end

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -54,7 +54,12 @@ module Barnes
         panels << Barnes::ResourceUsage.new(sample_rate)
       end
 
-      Periodic.new reporter: reporter, sample_rate: sample_rate, panels: panels
+      Periodic.new(
+        reporter:    reporter,
+        sample_rate: sample_rate,
+        panels:      panels,
+        debug:       ENV['BARNES_DEBUG']
+      )
     end
   end
 end

--- a/lib/barnes/instruments/puma_backlog.rb
+++ b/lib/barnes/instruments/puma_backlog.rb
@@ -78,10 +78,12 @@ module Barnes
         puts "Puma debug stats from barnes: #{stats}" if @debug
 
         pool_capacity = StatValue.new(stats, "pool_capacity").value
-        backlog       = StatValue.new(stats, "backlog").value
+        max_threads   = StatValue.new(stats, "max_threads").value
+        spawned       = StatValue.new(stats, "running").value
 
         gauges[:'pool.capacity']    = pool_capacity if pool_capacity
-        gauges[:'backlog.requests'] = backlog       if backlog
+        gauges[:'threads.max']      = max_threads   if max_threads
+        gauges[:'threads.spawned']  = spawned       if spawned
       end
     end
   end

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -28,10 +28,10 @@ module Barnes
   # to a reporting instance of `Barnes::Reporter` at a semi-regular
   # rate.
   class Periodic
-    def initialize(reporter:, sample_rate: 1, panels: [])
+    def initialize(reporter:, sample_rate: 1, debug: false, panels: [])
       @reporter = reporter
       @reporter.sample_rate = sample_rate
-
+      @debug = debug
       # compute interval based on a 60s reporting phase.
       @interval = sample_rate * 60.0
       @panels = panels
@@ -57,6 +57,8 @@ module Barnes
             @panels.each do |panel|
               panel.instrument! env[STATE], env[COUNTERS], env[GAUGES]
             end
+
+            puts env.to_json if @debug
             @reporter.report env
           end
         end

--- a/lib/barnes/version.rb
+++ b/lib/barnes/version.rb
@@ -22,5 +22,5 @@
 #
 
 module Barnes
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/test/fixtures/rack/hello_world/config.ru
+++ b/test/fixtures/rack/hello_world/config.ru
@@ -1,0 +1,8 @@
+$LOAD_PATH.append(File.expand_path(File.join("../../../../lib", __dir__)))
+
+require 'barnes'
+require 'puma'
+
+Barnes.start(interval: 1)
+
+run ->(env) { [200, {"Content-Type" => "text/html"}, ["Hello World!"]] }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class IntegrationTest < Minitest::Test
+  def test_puma
+    Dir.chdir(fixture_path("rack/hello_world")) do |dir|
+      WaitForIt.new("bundle exec puma", options) do |spawn|
+        spawn.wait('"barnes.gauges":', 1)
+        expect_spawn_to_contain(spawn, '"threads.spawned":0')
+      end
+    end
+  end
+
+  def options
+    port    = next_open_port
+    options = {}
+    options[:env] = {
+      "DYNO"         => "web.1",
+      "PORT"         => port,
+      "BARNES_DEBUG" => "1"
+    }
+    options[:wait_for] = "Use Ctrl-C to stop"
+    options
+  end
+
+  def expect_spawn_to_contain(spawn, string)
+    assert_equal true, !!spawn.contains?(string), "Expected #{spawn.log.read} to contain #{string.inspect} but it did not"
+  end
+end

--- a/test/lib/barnes/puma_stats_test.rb
+++ b/test/lib/barnes/puma_stats_test.rb
@@ -8,32 +8,34 @@ class PumaStatsTest < Minitest::Test
 
   def test_key_single
     expected = rand(3..99)
-    stat = stat_value({ "backlog" => expected }, "backlog")
+    stat = stat_value({ "pool_capacity" => expected }, "pool_capacity")
     assert_equal expected, stat.value
   end
 
   def test_key_cluster
     expected = rand(3..99)
     stat = stat_value({"workers" => 2, "worker_status" => [
-      {"last_status" => { "backlog" => expected }},
-      {"last_status" => { "backlog" => expected }}
-    ] }, "backlog")
+      {"last_status" => { "pool_capacity" => expected }},
+      {"last_status" => { "pool_capacity" => expected }}
+    ] }, "pool_capacity")
     assert_equal expected + expected, stat.value
   end
 
   def test_cluster_no_values
-    stat = stat_value({"workers"=>0, "phase"=>0, "booted_workers"=>0, "old_workers"=>0, "worker_status"=>[]}, "booted")
+    stats_hash = {"workers"=>0, "phase"=>0, "booted_workers"=>0, "old_workers"=>0, "worker_status"=>[]}
+    stat       = stat_value(stats_hash, "booted")
     assert_nil stat.value
   end
 
   def test_missing_key_single
     stats_hash = { "backlog" => 0, "running" => 0, "pool_capacity" => 16 }
-    stat = stat_value(stats_hash, "does_not_exist")
+    stat       = stat_value(stats_hash, "does_not_exist")
     assert_nil stat.value
   end
 
   def test_missing_key_cluster
-    stat = stat_value({"workers"=>2, "worker_status"=>[{"last_status" => {}}] }, "does_not_exist")
+    stats_hash = {"workers"=>2, "worker_status"=>[{"last_status" => {}}] }
+    stat       = stat_value(stats_hash, "does_not_exist")
     assert_nil stat.value
   end
 

--- a/test/lib/barnes/puma_stats_test.rb
+++ b/test/lib/barnes/puma_stats_test.rb
@@ -27,12 +27,32 @@ class PumaStatsTest < Minitest::Test
   end
 
   def test_missing_key_single
-    stat = stat_value({ "backlog" => 0, "running" => 0, "pool_capacity" => 16 }, "does_not_exist")
+    stats_hash = { "backlog" => 0, "running" => 0, "pool_capacity" => 16 }
+    stat = stat_value(stats_hash, "does_not_exist")
     assert_nil stat.value
   end
 
   def test_missing_key_cluster
     stat = stat_value({"workers"=>2, "worker_status"=>[{"last_status" => {}}] }, "does_not_exist")
     assert_nil stat.value
+  end
+
+  def test_max_threads_single
+    expected   = rand(3..99)
+    stats_hash = { "backlog" => 0, "running" => 0, "max_threads" => expected }
+    stat = stat_value(stats_hash, "max_threads")
+    assert_equal expected, stat.value
+  end
+
+  def test_max_threads_cluster
+    expected   = rand(3..99)
+    stats_hash = {
+      "workers" => 2, "worker_status" => [
+        {"last_status" => { "max_threads" => expected }},
+        {"last_status" => { "max_threads" => expected }}
+      ]
+    }
+    stat = stat_value(stats_hash, "max_threads")
+    assert_equal expected + expected, stat.value
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,43 @@
 require 'barnes'
 require 'minitest/autorun'
+require 'pathname'
 
+require 'wait_for_it'
 require 'simplecov'
 SimpleCov.start
+
+def fixture_path(path = "")
+  return Pathname.new(__dir__).join("fixtures").join(path).expand_path
+end
+
+
+require 'socket'
+require 'timeout'
+
+def is_port_open?(ip, port)
+  begin
+    Timeout::timeout(1) do
+      begin
+        s = TCPServer.new(ip, port)
+        s.listen(1024)
+        s.close
+        return true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+        puts e
+        return false
+      end
+    end
+  rescue Timeout::Error
+  end
+
+  return false
+end
+
+def next_open_port
+  (9292...10000).each do |port|
+    if is_port_open?('localhost', port)
+      return port
+    end
+  end
+  raise "Could not find a port"
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,6 @@ def is_port_open?(ip, port)
         s.close
         return true
       rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
-        puts e
         return false
       end
     end


### PR DESCRIPTION
- Adding “max threads” allows us to view pool capacity as a ratio of possible capacity rather than a stand alone number.
- Addin “spawned” threads helps people to visualize what their actual thread count is compared to maximum. While we recommend setting min=max this will help those who choose not to do that

- Adding integration tests that actually exercise puma codepaths.