### PR TITLE
Detect when app is using Puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     json (2.1.0)
     minitest (5.10.3)
     multi_json (1.13.1)
-    puma (3.11.4)
+    puma (3.12.0)
     rake (10.5.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     minitest (5.10.3)
     multi_json (1.13.1)
     puma (3.12.0)
+    rack (2.0.5)
     rake (10.5.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -30,6 +31,7 @@ DEPENDENCIES
   bundler (~> 1.15)
   minitest (~> 5.3)
   puma (~> 3.11)
+  rack (~> 2)
   rake (~> 10)
   simplecov
   wait_for_it (~> 0.1)

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'multi_json', '~> 1'
 
+  spec.add_development_dependency 'rack',     '~> 2'
   spec.add_development_dependency 'rake',     '~> 10'
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency "bundler",  '~> 1.15'

--- a/lib/barnes/instruments/puma_instrument.rb
+++ b/lib/barnes/instruments/puma_instrument.rb
@@ -2,7 +2,7 @@
 
 module Barnes
   module Instruments
-    class PumaBacklog
+    class PumaInstrument
       # This class is responsible for consuming a puma
       # generated stats hash that can come in two "flavors"
       # one is a "single process" server which will look like this:

--- a/lib/barnes/instruments/puma_instrument.rb
+++ b/lib/barnes/instruments/puma_instrument.rb
@@ -1,60 +1,18 @@
 # frozen_string_literal: true
 
+require 'barnes/instruments/puma_stats_value'
 module Barnes
   module Instruments
     class PumaInstrument
-      # This class is responsible for consuming a puma
-      # generated stats hash that can come in two "flavors"
-      # one is a "single process" server which will look like this:
-      #
-      #    { "backlog": 0, "running": 0, "pool_capacity": 16 }
-      #
-      # The other is a multiple cluster server that will look like this:
-      #
-      #    {"workers"=>2, "phase"=>0, "booted_workers"=>2, "old_workers"=>0, "worker_status"=>[{"pid"=>35020, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2018-05-21T19:53:18Z", "last_status"=>{"backlog"=>0, "running"=>5, "pool_capacity"=>5}}, {"pid"=>35021, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2018-05-21T19:53:18Z", "last_status"=>{"backlog"=>0, "running"=>5, "pool_capacity"=>5}}]}
-      #
-      class StatValue
-        attr_reader :stats, :key
-
-        def initialize(stats, key)
-          @stats   = stats
-          @key     = key
-          @cluster = stats.key?("worker_status")
-        end
-
-        def single?
-          !cluster?
-        end
-
-        def cluster?
-          @cluster
-        end
-
-        # For single worker process use value directly
-        # for multiple workers use the sum.
-        #
-        # https://github.com/puma/puma/pull/1532
-        def value
-          return stats[key] if single?
-          first_worker = stats["worker_status"].first
-          return nil unless first_worker && first_worker["last_status"].key?(key)
-
-          value = 0
-          stats["worker_status"].each do |worker_status|
-            value += worker_status["last_status"][key] || 0
-          end
-          return value
-        end
-      end
-
       def initialize(sample_rate=nil)
         @debug = ENV["BARNES_DEBUG_PUMA_STATS"]
+        @puma_has_stats = (defined?(::Puma) && ::Puma.respond_to?(:stats))
       end
 
       def valid?
-        defined?(Puma) &&
-          Puma.respond_to?(:stats) &&
-          ENV["DYNO"] && ENV["DYNO"].start_with?("web")
+        return false unless defined?(Puma)
+        return false unless ENV["DYNO"] && ENV["DYNO"].start_with?("web")
+        true
       end
 
       def start!(state)
@@ -62,7 +20,8 @@ module Barnes
       end
 
       def json_stats
-        MultiJson.load(Puma.stats || "{}")
+        return {} unless @puma_has_stats
+        MultiJson.load(::Puma.stats || "{}")
 
       # Puma loader has not been initialized yet
       rescue NoMethodError => e
@@ -72,6 +31,8 @@ module Barnes
       end
 
       def instrument!(state, counters, gauges)
+        gauges['using.puma'] = 1
+
         stats = json_stats
         return if stats.empty?
 

--- a/lib/barnes/instruments/puma_stats_value.rb
+++ b/lib/barnes/instruments/puma_stats_value.rb
@@ -1,0 +1,49 @@
+module Barnes
+  module Instruments
+    class PumaInstrument
+      # This class is responsible for consuming a puma
+      # generated stats hash that can come in two "flavors"
+      # one is a "single process" server which will look like this:
+      #
+      #    { "backlog": 0, "running": 0, "pool_capacity": 16 }
+      #
+      # The other is a multiple cluster server that will look like this:
+      #
+      #    {"workers"=>2, "phase"=>0, "booted_workers"=>2, "old_workers"=>0, "worker_status"=>[{"pid"=>35020, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2018-05-21T19:53:18Z", "last_status"=>{"backlog"=>0, "running"=>5, "pool_capacity"=>5}}, {"pid"=>35021, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2018-05-21T19:53:18Z", "last_status"=>{"backlog"=>0, "running"=>5, "pool_capacity"=>5}}]}
+      #
+      class StatValue
+        attr_reader :stats, :key
+
+        def initialize(stats, key)
+          @stats   = stats
+          @key     = key
+          @cluster = stats.key?("worker_status")
+        end
+
+        def single?
+          !cluster?
+        end
+
+        def cluster?
+          @cluster
+        end
+
+        # For single worker process use value directly
+        # for multiple workers use the sum.
+        #
+        # https://github.com/puma/puma/pull/1532
+        def value
+          return stats[key] if single?
+          first_worker = stats["worker_status"].first
+          return nil unless first_worker && first_worker["last_status"].key?(key)
+
+          value = 0
+          stats["worker_status"].each do |worker_status|
+            value += worker_status["last_status"][key] || 0
+          end
+          return value
+        end
+      end
+    end
+  end
+end

--- a/lib/barnes/resource_usage.rb
+++ b/lib/barnes/resource_usage.rb
@@ -29,10 +29,10 @@ module Barnes
       super()
 
       require 'barnes/instruments/puma_instrument'
-      backlog_reporter = Barnes::Instruments::PumaInstrument.new
+      puma_instrument = Barnes::Instruments::PumaInstrument.new
 
-      if backlog_reporter.valid?
-        instrument backlog_reporter
+      if puma_instrument.valid?
+        instrument puma_instrument
       end
 
       require 'barnes/instruments/stopwatch'

--- a/lib/barnes/resource_usage.rb
+++ b/lib/barnes/resource_usage.rb
@@ -28,8 +28,8 @@ module Barnes
     def initialize(sample_rate)
       super()
 
-      require 'barnes/instruments/puma_backlog'
-      backlog_reporter = Barnes::Instruments::PumaBacklog.new
+      require 'barnes/instruments/puma_instrument'
+      backlog_reporter = Barnes::Instruments::PumaInstrument.new
 
       if backlog_reporter.valid?
         instrument backlog_reporter

--- a/test/fixtures/rack/no_puma/config.ru
+++ b/test/fixtures/rack/no_puma/config.ru
@@ -1,0 +1,7 @@
+$LOAD_PATH.append(File.expand_path(File.join("../../../../lib", __dir__)))
+
+require 'barnes'
+
+Barnes.start(interval: 1)
+
+run ->(env) { [200, {"Content-Type" => "text/html"}, ["Hello World!"]] }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,6 +6,7 @@ class IntegrationTest < Minitest::Test
       WaitForIt.new("bundle exec puma", options) do |spawn|
         spawn.wait('"barnes.gauges":', 1)
         expect_spawn_to_contain(spawn, '"threads.spawned":0')
+        expect_spawn_to_contain(spawn, '"using.puma":1')
       end
     end
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -11,6 +11,15 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_no_puma
+    Dir.chdir(fixture_path("rack/no_puma")) do |dir|
+      WaitForIt.new("bundle exec rackup", options) do |spawn|
+        spawn.wait('"barnes.gauges":', 1)
+        spawn_should_not_contain(spawn, '"using.puma":1')
+      end
+    end
+  end
+
   def options
     port    = next_open_port
     options = {}
@@ -23,7 +32,11 @@ class IntegrationTest < Minitest::Test
     options
   end
 
-  def expect_spawn_to_contain(spawn, string)
-    assert_equal true, !!spawn.contains?(string), "Expected #{spawn.log.read} to contain #{string.inspect} but it did not"
+  def spawn_should_not_contain(spawn, string)
+    expect_spawn_to_contain(spawn, string, does_contain: false)
+  end
+
+  def expect_spawn_to_contain(spawn, string, does_contain: true)
+    assert_equal does_contain, !!spawn.contains?(string), "Expected #{spawn.log.read} to contain #{string.inspect} but it did not"
   end
 end

--- a/test/lib/barnes/puma_stats_test.rb
+++ b/test/lib/barnes/puma_stats_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
-require 'barnes/instruments/puma_backlog'
+require 'barnes/instruments/puma_instrument'
 
 class PumaStatsTest < Minitest::Test
   def stat_value(stats, key)
-    ::Barnes::Instruments::PumaBacklog::StatValue.new(stats, key)
+    ::Barnes::Instruments::PumaInstrument::StatValue.new(stats, key)
   end
 
   def test_key_single


### PR DESCRIPTION
When the app is using puma then we send a value of `1` this allows us to detect if the app should be sending a specific stat but it is not due to using an older version of Puma.

As part of this work I renamed `PumaBacklog` to `PumaInstrument` since we're no longer recording backlog.