### PR TITLE
Test before_fork behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'simplecov', :require => false, :group => :test
+gem 'm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,10 @@ GEM
   specs:
     docile (1.1.5)
     json (2.1.0)
+    m (1.5.1)
+      method_source (>= 0.6.7)
+      rake (>= 0.9.2.2)
+    method_source (0.9.0)
     minitest (5.10.3)
     multi_json (1.13.1)
     puma (3.12.0)
@@ -29,12 +33,13 @@ PLATFORMS
 DEPENDENCIES
   barnes!
   bundler (~> 1.15)
+  m
   minitest (~> 5.3)
-  puma (~> 3.11)
+  puma (~> 3.12)
   rack (~> 2)
   rake (~> 10)
   simplecov
   wait_for_it (~> 0.1)
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',     '~> 10'
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency "bundler",  '~> 1.15'
-  spec.add_development_dependency "puma",     '~> 3.11'
+  spec.add_development_dependency "puma",     '~> 3.12'
   spec.add_development_dependency "wait_for_it",     '~> 0.1'
 end

--- a/test/fixtures/rack/workers/config.rb
+++ b/test/fixtures/rack/workers/config.rb
@@ -1,0 +1,23 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+if ENV["INSERT_BARNES_BEFORE_FORK"]
+  before_fork do
+    require 'barnes'
+    Barnes.start(interval: 1)
+  end
+end
+
+if ENV["INSERT_BARNES_ON_WORKER_BOOT"]
+  on_worker_boot do
+    require 'barnes'
+    Barnes.start(interval: 1)
+  end
+end

--- a/test/fixtures/rack/workers/config.ru
+++ b/test/fixtures/rack/workers/config.ru
@@ -1,0 +1,5 @@
+$LOAD_PATH.append(File.expand_path(File.join("../../../../lib", __dir__)))
+
+require 'puma'
+
+run ->(env) { [200, {"Content-Type" => "text/html"}, ["Hello World!"]] }


### PR DESCRIPTION
It turns out that we actually don't want barnes to start in the worker, but instead we want it on the "primary" process. This happens to occur by default if you're using Rails as we have a railtie that boots barnes when rails is loaded which executes in the "primary" process.

This test confirms this behavior but doesn't functionally change anything about barnes.