### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then run:
 $ bundle install
 ```
 
-In your application:
+In your puma.rb file:
 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ require 'barnes'
 Then you'll need to start the client with default values:
 
 ```ruby
-Barnes.start
+before_fork do
+  # worker configuration
+  Barnes.start
+end
 ```
 


### PR DESCRIPTION
It's misleading where to put Barnes dependencies
```
require 'barnes' 
Barnes.start
```
if you do this in initializers, puma metrics won't show up on heroku metrics page.