### PR TITLE
Mention support for Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A fork of [trashed](https://github.com/basecamp/trashed) focused on Ruby metrics
 
 ## Setup
 
-### Rails 5
+### Rails 3, 4, 5, and 6
 
-On Rails 5 (and Rails 3 and 4), add this to your Gemfile:
+On Rails 6 (and Rails 3 and 4 and 5), add this to your Gemfile:
 
 ```
 gem "barnes"


### PR DESCRIPTION
I added barnes to my rails 6 app and it seems to be working just fine, so I don't think any special instructions are necessary to get it up and running on a rails 6 app. Therefore, I just generalized the rails 5 instructions to also mention rails 6. :rocket: 