### PR TITLE
Fix warnings for Ruby 2.7.0

### DIFF
--- a/lib/barnes/railtie.rb
+++ b/lib/barnes/railtie.rb
@@ -41,7 +41,7 @@ module Barnes
     }
 
     initializer 'barnes' do |app|
-      Barnes.start(config.barnes)
+      Barnes.start(**config.barnes)
     end
   end
 end


### PR DESCRIPTION
Spotted from deploying to Heroku with Ruby 2.7.0:

```
/tmp/build_f9909856d22940c52afed60118ed2593/vendor/bundle/ruby/2.7.0/gems/barnes-0.0.7/lib/barnes/railtie.rb:44: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/build_f9909856d22940c52afed60118ed2593/vendor/bundle/ruby/2.7.0/gems/barnes-0.0.7/lib/barnes.rb:40: warning: The called method `start' is defined here
```