### PR TITLE
Allow any "nil" thing to fail gracefully inside Puma reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master (unrleased)
 
+- Handle half-initialize Puma failure on boot
+
 ## 0.0.8
 
 - Fix warnings in Ruby 2.7

--- a/lib/barnes/instruments/puma_instrument.rb
+++ b/lib/barnes/instruments/puma_instrument.rb
@@ -26,7 +26,6 @@ module Barnes
       # Puma loader has not been initialized yet
       rescue NoMethodError => e
         raise e unless e.message =~ /nil/
-        raise e unless e.message =~ /stats/
         return {}
       end
 


### PR DESCRIPTION
I was getting this exception on booting an app on Heroku (intermittantly):

```
2021-01-15T05:34:28.336784+00:00 app[web.1]: #<Thread:0x00007f0178d27140@/app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:39 run> terminated with exception (report_on_exception is true):
2021-01-15T05:34:28.337033+00:00 app[web.1]: /app/vendor/bundle/ruby/2.6.0/gems/puma-4.3.7/lib/puma/single.rb:17:in `stats': undefined method `backlog' for nil:NilClass (NoMethodError)
2021-01-15T05:34:28.337064+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/puma-4.3.7/lib/puma.rb:23:in `stats'
2021-01-15T05:34:28.337094+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/instruments/puma_instrument.rb:24:in `json_stats'
2021-01-15T05:34:28.337120+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/instruments/puma_instrument.rb:36:in `instrument!'
2021-01-15T05:34:28.337146+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/panel.rb:46:in `block in instrument!'
2021-01-15T05:34:28.337238+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/panel.rb:45:in `each'
2021-01-15T05:34:28.337265+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/panel.rb:45:in `instrument!'
2021-01-15T05:34:28.337290+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:58:in `block (3 levels) in initialize'
2021-01-15T05:34:28.337316+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:57:in `each'
2021-01-15T05:34:28.337370+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:57:in `block (2 levels) in initialize'
2021-01-15T05:34:28.337398+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:46:in `loop'
2021-01-15T05:34:28.337423+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.6.0/gems/barnes-0.0.8/lib/barnes/periodic.rb:46:in `block in initialize'
2021-01-15T05:34:28.337640+00:00 app[web.1]: ! Unable to load application: NoMethodError: undefined method `backlog' for nil:NilClass
```

The existing code is more-or-less designed to catch the situation where Puma hasn't started yet, so the call fails with an exception in the `stats` method (when it tries to call `stats` on the inner object).  This one above happens when the inner object has actually been created, so the exception happens elsewhere, and the method being called is something else.