### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.5.0
-before_install: gem install bundler -v 2.1.0


### PR DESCRIPTION
Since we're no longer using Travis CI, so CI is broken anyway, and this file is causing confusion.

At whatever point that someone wants to work on this repo again, they can add a Circle CI or GitHub Actions config.