### PR TITLE
remove MultiJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (unreleased)
 
 - Add GitHub Actions to test against multiple Ruby versions
+- remove MultiJSON in favor of built-in JSON
 
 ## 0.0.9
 

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
+  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'logger'
-  spec.add_runtime_dependency 'multi_json', '~> 1'
   spec.add_runtime_dependency 'ostruct'
   spec.add_runtime_dependency 'statsd-ruby', '~> 1.1'
 

--- a/lib/barnes/instruments/puma_instrument.rb
+++ b/lib/barnes/instruments/puma_instrument.rb
@@ -16,12 +16,12 @@ module Barnes
       end
 
       def start!(state)
-        require 'multi_json'
+        require 'json'
       end
 
       def json_stats
         return {} unless @puma_has_stats
-        MultiJson.load(::Puma.stats || "{}")
+        JSON.load(::Puma.stats || "{}")
 
       # Puma loader has not been initialized yet
       rescue NoMethodError => e


### PR DESCRIPTION
using the built-in JSON module because it has gotten really good over time. There is no need for a third-party dependency.

https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html
https://byroot.github.io/ruby/json/2024/12/18/optimizing-ruby-json-part-2.html
https://byroot.github.io/ruby/json/2024/12/27/optimizing-ruby-json-part-3.html
https://byroot.github.io/ruby/json/2024/12/29/optimizing-ruby-json-part-4.html
