### PR TITLE
Limit barnes reporters to one at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fix: Previously calling `Barnes.start` would result in duplicate reporting threads. Now when this method is called, old threads are stopped before a new thread being invoked.
+
 ## 1.0.0
 
 - **Breaking**: Replace StatsD with direct HTTP reporting to HEROKU_METRICS_URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (unreleased)
 
-- Fix: Previously calling `Barnes.start` would result in duplicate reporting threads. Now when this method is called, old threads are stopped before a new thread being invoked.
+- Fix: Previously calling `Barnes.start` would result in duplicate reporting threads. Now when this method is called, old threads are stopped before a new thread is started.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+## 1.0.1
+
 - Fix: Previously calling `Barnes.start` would result in duplicate reporting threads. Now when this method is called, old threads are stopped before a new thread is started.
 
 ## 1.0.0

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -53,7 +53,7 @@ module Barnes
     if @periodic
       debug("Restarting Barnes. Previously started by caller:")
       debug(@caller.join("\n"))
-      @periodic.stop
+      @periodic.stop(wait: false)
     end
 
     @caller = caller

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -26,6 +26,7 @@ module Barnes
   DEFAULT_PANELS   = [].freeze
   @caller = nil
   @periodic = nil
+  @mutex = Mutex.new
 
   # Starts the metrics reporting client.
   #
@@ -43,26 +44,28 @@ module Barnes
     url = ENV["HEROKU_METRICS_URL"]
     return unless url
 
-    reporter = Barnes::Reporter.new(url: url)
+    @mutex.synchronize do
+      reporter = Barnes::Reporter.new(url: url)
 
-    panels = panels.dup
-    if panels.empty?
-      panels << Barnes::ResourceUsage.new
+      panels = panels.dup
+      if panels.empty?
+        panels << Barnes::ResourceUsage.new
+      end
+
+      if @periodic
+        debug("Restarting Barnes. Previously started by caller:")
+        debug(@caller.join("\n"))
+        @periodic.stop(wait: false)
+      end
+
+      @caller = caller
+      @periodic = Periodic.new(
+        reporter: reporter,
+        interval: interval,
+        panels:   panels,
+        debug:    ENV['BARNES_DEBUG']
+      )
     end
-
-    if @periodic
-      debug("Restarting Barnes. Previously started by caller:")
-      debug(@caller.join("\n"))
-      @periodic.stop(wait: false)
-    end
-
-    @caller = caller
-    @periodic = Periodic.new(
-      reporter: reporter,
-      interval: interval,
-      panels:   panels,
-      debug:    ENV['BARNES_DEBUG']
-    )
   end
 
   def self.debug(message)

--- a/lib/barnes.rb
+++ b/lib/barnes.rb
@@ -24,6 +24,8 @@
 module Barnes
   DEFAULT_INTERVAL = 10
   DEFAULT_PANELS   = [].freeze
+  @caller = nil
+  @periodic = nil
 
   # Starts the metrics reporting client.
   #
@@ -48,12 +50,25 @@ module Barnes
       panels << Barnes::ResourceUsage.new
     end
 
-    Periodic.new(
+    if @periodic
+      debug("Restarting Barnes. Previously started by caller:")
+      debug(@caller.join("\n"))
+      @periodic.stop
+    end
+
+    @caller = caller
+    @periodic = Periodic.new(
       reporter: reporter,
       interval: interval,
       panels:   panels,
       debug:    ENV['BARNES_DEBUG']
     )
+  end
+
+  def self.debug(message)
+    if ENV["BARNES_DEBUG"]
+      puts "Barnes: #{message}"
+    end
   end
 end
 

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -26,6 +26,8 @@ require 'json'
 
 module Barnes
   class Periodic
+    attr_reader :thread
+
     def initialize(reporter:, interval: 10, debug: false, panels: [])
       @reporter = reporter
       @debug = debug

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -31,6 +31,7 @@ module Barnes
       @debug = debug
       @interval = interval
       @panels = panels
+      @stopping = false
 
       @thread = Thread.new {
         Thread.current[:barnes_state] = {}
@@ -42,6 +43,7 @@ module Barnes
         loop do
           begin
             sleep @interval
+            break if @stopping
 
             env = {
               STATE    => Thread.current[:barnes_state],
@@ -63,8 +65,10 @@ module Barnes
       @thread.abort_on_exception = true
     end
 
-    def stop
-      @thread.exit
+    def stop(wait: )
+      @stopping = true
+      @thread.wakeup if @thread.alive?
+      @thread.join if wait
     end
   end
 end

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -43,25 +43,23 @@ module Barnes
         end
 
         loop do
-          begin
-            sleep @interval
-            break if @stopping
+          sleep @interval
+          break if @stopping
 
-            env = {
-              STATE    => Thread.current[:barnes_state],
-              COUNTERS => {},
-              GAUGES   => {}
-            }
+          env = {
+            STATE    => Thread.current[:barnes_state],
+            COUNTERS => {},
+            GAUGES   => {}
+          }
 
-            @panels.each do |panel|
-              panel.instrument! env[STATE], env[COUNTERS], env[GAUGES]
-            end
-
-            puts env.to_json if @debug
-            @reporter.report env
-          rescue => e
-            $stderr.puts "barnes: error during metrics collection: #{e.class}: #{e.message}"
+          @panels.each do |panel|
+            panel.instrument! env[STATE], env[COUNTERS], env[GAUGES]
           end
+
+          puts env.to_json if @debug
+          @reporter.report env
+        rescue => e
+          $stderr.puts "barnes: error during metrics collection: #{e.class}: #{e.message}"
         end
       }
     end

--- a/lib/barnes/periodic.rb
+++ b/lib/barnes/periodic.rb
@@ -62,7 +62,6 @@ module Barnes
           end
         end
       }
-      @thread.abort_on_exception = true
     end
 
     def stop(wait: )

--- a/lib/barnes/version.rb
+++ b/lib/barnes/version.rb
@@ -22,5 +22,5 @@
 #
 
 module Barnes
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/fixtures/rack/workers/config.rb
+++ b/test/fixtures/rack/workers/config.rb
@@ -15,6 +15,14 @@ if ENV["INSERT_BARNES_BEFORE_FORK"]
   end
 end
 
+if ENV["DOUBLE_BARNES_BEFORE_FORK"]
+  before_fork do
+    require 'barnes'
+    Barnes.start(interval: 1)
+    Barnes.start(interval: 1)
+  end
+end
+
 if ENV["INSERT_BARNES_ON_WORKER_BOOT"]
   on_worker_boot do
     require 'barnes'

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -32,6 +32,16 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_double_start_stops_previous
+    Dir.chdir(fixture_path("rack/workers")) do |dir|
+      WaitForIt.new("bundle exec puma -C ./config.rb",
+        options(DOUBLE_BARNES_BEFORE_FORK: "true")) do |spawn|
+        spawn.wait("Restarting Barnes", 7)
+        expect_spawn_to_contain(spawn, "Restarting Barnes")
+      end
+    end
+  end
+
   def test_workers_on_boot
     Dir.chdir(fixture_path("rack/workers")) do |dir|
       WaitForIt.new("bundle exec puma -C ./config.rb",

--- a/test/periodic_test.rb
+++ b/test/periodic_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require 'barnes/periodic'
+
+class PeriodicTest < Minitest::Test
+  def test_report_called_and_stop_works
+    report_count = 0
+    mutex = Mutex.new
+    reporter = Object.new
+    reporter.define_singleton_method(:report) { |_| mutex.synchronize { report_count += 1 } }
+
+    periodic = Barnes::Periodic.new(reporter: reporter, interval: 0.1)
+    while mutex.synchronize { report_count } < 1
+      sleep 0.1
+    end
+
+    assert periodic.thread.alive?, "Expected thread to be alive"
+    periodic.stop(wait: true)
+    refute periodic.thread.alive?, "Expected thread to be stopped"
+  ensure
+    if periodic&.thread&.alive?
+      periodic.thread.exit
+      periodic.thread.join
+    end
+  end
+end


### PR DESCRIPTION
When calling `Barnes.start` manually in a Rails app, the reporter is started once in the railtie and again in the manual call:

```
$ WEB_CONCURRENCY=2 bin/puma -C config/puma.rb
[66897] Puma starting in cluster mode...
...
== CALLED Barnes.start
/Users/rschneeman/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/barnes-1.0.0/lib/barnes/railtie.rb:42:in 'block in <class:Railtie>'
...
== CALLED Barnes.start
config/puma.rb:25:in 'block in Puma::DSL#_load_from'
/Users/rschneeman/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/puma-8.0.1/lib/puma/configuration.rb:356:in 'block in Puma::Configuration#run_hooks'
```

Now, when `Barnes.start` is called it will stop any prior running reporting threads first.

GUS-W-22680798