### PR TITLE
Reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,9 @@
+# Default to requesting pull request reviews from the Heroku Languages team.
 #ECCN:Open Source
 #GUSINFO:Heroku - Languages,Heroku Ruby Platform
 * @heroku/languages
+
+# However, request review from the language owner instead for files that are updated
+# by Dependabot, to reduce team review request noise.
+barnes.gemspec @schneems
+/.github/workflows/ @schneems


### PR DESCRIPTION
Similar to what we do for other language-specific repos, this ensures that review requests for Dependabot PRs (such as #48 or #56) are requested from the language owner rather than than team alias.

GUS-W-22817257.