### PR TITLE
Receiving 401 responses on dyno shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fix: Skip logging `metrics POST rejected (401): dynoidmap: no dyno information exists for that UUID` on dyno shutdown. This is accomplished by ignoring 401 status responses from the API for the first 90 seconds. Setting `BARNES_DEBUG=1` will bypass the delay.
+
 ## 1.0.1
 
 - Fix: Previously calling `Barnes.start` would result in duplicate reporting threads. Now when this method is called, old threads are stopped before a new thread is started.

--- a/barnes.gemspec
+++ b/barnes.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency "puma",     '~> 5.6'
   spec.add_development_dependency "wait_for_it",     '~> 0.1'
+  spec.add_development_dependency "timecop"
 end

--- a/lib/barnes/reporter.rb
+++ b/lib/barnes/reporter.rb
@@ -32,12 +32,14 @@ module Barnes
 
     ServerError = Class.new(StandardError)
 
-    def initialize(url:, backoff_sleep: ->(n) { sleep(n) }, io: $stderr)
+    def initialize(url:, backoff_sleep: ->(n) { sleep(n) }, io: $stderr, debug: ENV["BARNES_DEBUG"])
       @io = io
       @uri = URI.parse(url)
+      @debug = debug
       @backoff_sleep = backoff_sleep
       @mutex = Mutex.new
       @http = nil
+      @first_401 = nil
     end
 
     def report(env)
@@ -86,6 +88,14 @@ module Barnes
         case response.code.to_i
         when 200..299
           # success
+        when 401
+          @first_401 ||= Time.now
+
+          # Quiet expected status code while dyno is shutting down
+          # https://github.com/heroku/barnes/issues/58
+          if @debug || (Time.now - @first_401) > 90 # seconds
+            @io.puts "barnes: metrics POST rejected (#{response.code}): #{response.body}"
+          end
         when 400..499
           @io.puts "barnes: metrics POST rejected (#{response.code}): #{response.body}"
         when 500..599

--- a/lib/barnes/reporter.rb
+++ b/lib/barnes/reporter.rb
@@ -32,7 +32,8 @@ module Barnes
 
     ServerError = Class.new(StandardError)
 
-    def initialize(url:, backoff_sleep: ->(n) { sleep(n) })
+    def initialize(url:, backoff_sleep: ->(n) { sleep(n) }, io: $stderr)
+      @io = io
       @uri = URI.parse(url)
       @backoff_sleep = backoff_sleep
       @mutex = Mutex.new
@@ -86,7 +87,7 @@ module Barnes
         when 200..299
           # success
         when 400..499
-          $stderr.puts "barnes: metrics POST rejected (#{response.code}): #{response.body}"
+          @io.puts "barnes: metrics POST rejected (#{response.code}): #{response.body}"
         when 500..599
           raise ServerError, "server error #{response.code}"
         end
@@ -101,12 +102,12 @@ module Barnes
           pause *= 2
           retry
         else
-          $stderr.puts "barnes: failed to POST metrics after #{MAX_RETRIES} retries: #{e.class}: #{e.message}"
+          @io.puts "barnes: failed to POST metrics after #{MAX_RETRIES} retries: #{e.class}: #{e.message}"
         end
       rescue => e
         @http&.finish rescue nil
         @http = nil
-        $stderr.puts "barnes: unexpected error posting metrics: #{e.class}: #{e.message}"
+        @io.puts "barnes: unexpected error posting metrics: #{e.class}: #{e.message}"
       end
     end
   end

--- a/lib/barnes/reporter.rb
+++ b/lib/barnes/reporter.rb
@@ -93,7 +93,7 @@ module Barnes
 
           # Quiet expected status code while dyno is shutting down
           # https://github.com/heroku/barnes/issues/58
-          if @debug || (Time.now - @first_401) > 90 # seconds
+          if @debug || (Time.now - @first_401) > 30 # seconds
             @io.puts "barnes: metrics POST rejected (#{response.code}): #{response.body}"
           end
         when 400..499

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -192,13 +192,13 @@ class ReporterTest < Minitest::Test
     end
     assert_empty io.string
 
-    Timecop.freeze(now + 89) do
+    Timecop.freeze(now + 29) do
       accept_one_request(status: "401 Unauthorized")
       reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
     end
     assert_empty io.string
 
-    Timecop.freeze(now + 91) do
+    Timecop.freeze(now + 31) do
       accept_one_request(status: "401 Unauthorized")
       reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
     end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -3,6 +3,7 @@ require 'barnes/reporter'
 require 'json'
 require 'socket'
 require 'stringio'
+require 'timecop'
 
 class ReporterTest < Minitest::Test
   def setup
@@ -174,6 +175,50 @@ class ReporterTest < Minitest::Test
 
     wait_for_requests(1)
     assert_equal 1, @requests.size
+  end
+
+  def test_401_is_silent_within_90_seconds
+    io = StringIO.new
+    now = Time.now
+    reporter = Barnes::Reporter.new(
+      url: "http://127.0.0.1:#{@port}/metrics",
+      backoff_sleep: ->(_) {},
+      io: io
+    )
+
+    Timecop.freeze(now) do
+      accept_one_request(status: "401 Unauthorized")
+      reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
+    end
+    assert_empty io.string
+
+    Timecop.freeze(now + 89) do
+      accept_one_request(status: "401 Unauthorized")
+      reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
+    end
+    assert_empty io.string
+
+    Timecop.freeze(now + 91) do
+      accept_one_request(status: "401 Unauthorized")
+      reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
+    end
+    assert_includes io.string, "barnes: metrics POST rejected (401)"
+  end
+
+  def test_401_prints_immediately_with_barnes_debug
+    io = StringIO.new
+    reporter = Barnes::Reporter.new(
+      url: "http://127.0.0.1:#{@port}/metrics",
+      backoff_sleep: ->(_) {},
+      debug: true,
+      io: io
+    )
+
+    Timecop.freeze do
+      accept_one_request(status: "401 Unauthorized")
+      reporter.report(Barnes::COUNTERS => { :'GC.count' => 1 }, Barnes::GAUGES => {})
+    end
+    assert_includes io.string, "barnes: metrics POST rejected (401)"
   end
 
   private


### PR DESCRIPTION
When the dyno is shutting down, there's a race condition where the component might be unregistered with the API that Heroku uses to capture metrics before the dyno finishes fully shutting down. That means there's a window where a dyno still going through a clean SIGTERM shutdown could still be sending metrics, but the API doesn't recognize the dyno.

To avoid this from cluttering logs when the dyno is restarted, delay printing 401 warnings for 90 seconds. This will give the dyno time to shut down safely with some buffer room https://devcenter.heroku.com/articles/error-codes#r12-exit-timeout. Anyone debugging connection issues via BARNES_DEBUG will see the warnings right away.

Closes #58